### PR TITLE
GitHub Pages: fix missing odoc content

### DIFF
--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -19,15 +19,13 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: "5.1.1"
+          # disable cache, otherwise generated documentation is missing files
           dune-cache: false
 
       - run: opam install . --deps-only --with-doc
         shell: bash
 
       - run: opam exec -- dune build --verbose @doc
-        shell: bash
-
-      - run: find _build/default/_doc/_html
         shell: bash
 
       - name: Deploy odoc to GitHub Pages

--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -19,15 +19,12 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: "5.1.1"
-          dune-cache: true
+          dune-cache: false
 
       - run: opam install . --deps-only --with-doc
         shell: bash
 
-      # - run: opam depext --install odoc
-      #   shell: bash
-
-      - run: opam exec -- dune build @doc
+      - run: opam exec -- dune build --verbose @doc
         shell: bash
 
       - run: find _build/default/_doc/_html

--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set-up OCaml 5.1.1
         uses: ocaml/setup-ocaml@v2
@@ -21,10 +21,21 @@ jobs:
           ocaml-compiler: "5.1.1"
           dune-cache: true
 
+      - run: opam install . --deps-only --with-doc
+        shell: bash
+
+      # - run: opam depext --install odoc
+      #   shell: bash
+
+      - run: opam exec -- dune build @doc
+        shell: bash
+
+      - run: find _build/default/_doc/_html
+        shell: bash
+
       - name: Deploy odoc to GitHub Pages
-        # last version of setup-ocaml with deploy-doc
-        # TODO: https://github.com/ocaml/setup-ocaml/blob/master/EXAMPLES.md
-        #   #using-the-official-github-pages-actions-to-deploy-odoc-to-github-pages
-        uses: ocaml/setup-ocaml/deploy-doc@v2.1.8
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          destination-dir: ${{ github.head_ref || github.ref_name }}
+          github_token: ${{ github.token }}
+          publish_dir: _build/default/_doc/_html
+          destination_dir: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
Disabling the dune cache apparently fixes the issue.

Also remove the deprecated `ocaml/setup-ocaml/deploy-doc` action by more or less inlining it.